### PR TITLE
fix: invoke `end` callback when no chunk is passed

### DIFF
--- a/src/stream/writable.ts
+++ b/src/stream/writable.ts
@@ -96,12 +96,15 @@ export class Writable extends EventEmitter implements NodeStream.Writable {
     const data = arg1 === callback ? undefined : arg1;
     if (data) {
       const encoding = arg2 === callback ? undefined : arg2;
-      this.write(data, encoding, callback);
+      this.write(data, encoding);
     }
     this.writableEnded = true;
     this.writableFinished = true;
     this.emit("close");
     this.emit("finish");
+    if (callback) {
+      callback();
+    }
     return this;
   }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -112,3 +112,44 @@ describe("fetchNodeRequestHandler", () => {
     });
   });
 });
+
+describe("ServerResponse#end callback", () => {
+  it("invokes callback with no chunk", async () => {
+    const calls: string[] = [];
+    const res = await fetchNodeRequestHandler((_req, res) => {
+      res.on("finish", () => calls.push("finish"));
+      res.end(() => calls.push("callback"));
+    }, "/test");
+    expect(await res.text()).toBe("");
+    expect(calls).toEqual(["finish", "callback"]);
+  });
+
+  it("invokes callback once with chunk", async () => {
+    const calls: string[] = [];
+    const res = await fetchNodeRequestHandler((_req, res) => {
+      res.on("finish", () => calls.push("finish"));
+      res.end("hello", () => calls.push("callback"));
+    }, "/test");
+    expect(await res.text()).toBe("hello");
+    expect(calls).toEqual(["finish", "callback"]);
+  });
+
+  it("invokes callback once with chunk and encoding", async () => {
+    let calls = 0;
+    const res = await fetchNodeRequestHandler((_req, res) => {
+      res.end("hello", "utf8", () => calls++);
+    }, "/test");
+    expect(await res.text()).toBe("hello");
+    expect(calls).toBe(1);
+  });
+
+  it("invokes callback on an already ended response", async () => {
+    let calls = 0;
+    const res = await fetchNodeRequestHandler((_req, res) => {
+      res.end("hello");
+      res.end(() => calls++);
+    }, "/test");
+    expect(await res.text()).toBe("hello");
+    expect(calls).toBe(1);
+  });
+});


### PR DESCRIPTION
reproducible in https://github.com/nuxt/image/pull/2094

the ServerResponse never invokes `cb` when called without a chunk: the callback is detected, the write branch is skipped, `writableEnded`/`writableFinished` are set and `close`/`finish` emitted, but the promise never settles.

```ts
const ipx = createIPX({ storage: ipxFSStorage({ dir: 'some/dir' }) })
await fetchNodeRequestHandler(createIPXNodeHandler(ipx), '/s_300x300/images/colors.jpg') // hangs
```

 this PR calls the callback after `finish` is emitted, and stops forwarding it to `write()` so it still fires exactly once (and after finish) when a chunk was passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected response completion callback timing so callbacks run after the response has finished closing.
  * Ensured callbacks are invoked exactly once, including when ending a response with data, an encoding, or after it has already ended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->